### PR TITLE
Skip if instances is empty

### DIFF
--- a/src/DapperRepository.BulkInsert.cs
+++ b/src/DapperRepository.BulkInsert.cs
@@ -81,10 +81,13 @@ public partial class DapperRepository<TEntity>
 
     public virtual async Task<int> BulkInsertAsync(IEnumerable<TEntity> instances, IDbTransaction? transaction, CancellationToken cancellationToken)
     {
+        int totalInstances = instances.Count();
+        if (totalInstances == 0)
+            return 0;
+
         if (SqlGenerator.Provider == SqlProvider.MSSQL)
         {
             var count = 0;
-            var totalInstances = instances.Count();
 
             var properties =
                 (SqlGenerator.IsIdentity

--- a/src/DapperRepository.BulkUpdate.cs
+++ b/src/DapperRepository.BulkUpdate.cs
@@ -76,10 +76,13 @@ public partial class DapperRepository<TEntity>
 
     public virtual async Task<bool> BulkUpdateAsync(IEnumerable<TEntity> instances, IDbTransaction? transaction, CancellationToken cancellationToken)
     {
+        int totalInstances = instances.Count();
+        if (totalInstances == 0)
+            return true;
+
         if (SqlGenerator.Provider == SqlProvider.MSSQL)
         {
             int count = 0;
-            int totalInstances = instances.Count();
 
             var properties = SqlGenerator.SqlProperties.ToList();
 


### PR DESCRIPTION
Add validation to skip processing when instances collection is empty to prevent unnecessary execution.