### PR TITLE
Fix array Contains under C# 14

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <IsPackable>false</IsPackable>
     <NoWarn>CS1591;NETSDK1138</NoWarn>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/src/SqlGenerator/ExpressionHelper.cs
+++ b/src/SqlGenerator/ExpressionHelper.cs
@@ -179,8 +179,8 @@ internal static class ExpressionHelper
 
     public static object? GetValuesFromCollection(MethodCallExpression callExpr)
     {
-        var expr = (callExpr.Method.IsStatic ? callExpr.Arguments.First() : callExpr.Object)
-            as MemberExpression;
+        var collection = callExpr.Method.IsStatic ? callExpr.Arguments.First() : callExpr.Object;
+        var expr = UnwrapSpanConversion(collection) as MemberExpression;
 
         try
         {
@@ -190,6 +190,22 @@ internal static class ExpressionHelper
         {
             throw new NotSupportedException(callExpr.Method.Name + " isn't supported");
         }
+    }
+
+    /// <summary>
+    /// Unwraps the implicit array to span conversion the compiler inserts since C# 14,
+    /// when <c>array.Contains(x)</c> binds to <c>MemoryExtensions.Contains</c> instead of <c>Enumerable.Contains</c>.
+    /// </summary>
+    private static Expression? UnwrapSpanConversion(Expression? expr)
+    {
+        if (expr is MethodCallExpression { Method: { IsSpecialName: true, Name: "op_Implicit" }, Arguments.Count: 1 } conversion
+            && conversion.Type.Name is "ReadOnlySpan`1" or "Span`1")
+            expr = conversion.Arguments[0];
+
+        while (expr is UnaryExpression { NodeType: ExpressionType.Convert or ExpressionType.ConvertChecked } unary)
+            expr = unary.Operand;
+
+        return expr;
     }
 
     public static MemberExpression? GetMemberExpression(Expression? expression)

--- a/tests/SqlGenerator.Tests/MSSQLGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/MSSQLGeneratorTests.cs
@@ -294,6 +294,36 @@ public class MSSQLGeneratorTests
     }
 
     [Fact]
+    public static void ContainsFilledArrayPredicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+        var ids = new[] { 1, 2, 3 };
+        var sqlQuery = sqlGenerator.GetSelectAll(x => ids.Contains(x.Id), null);
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.Equal(ids, parameters["Id_p0"]);
+
+        Assert.Equal(
+            "SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
+            "FROM [Users] WHERE ([Users].[Id] IN @Id_p0) AND [Users].[Deleted] IS NULL", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void ContainsStringArrayPredicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+        var names = new[] { "TestName0", "TestName1" };
+        var sqlQuery = sqlGenerator.GetSelectAll(x => names.Contains(x.Name), null);
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.Equal(names, parameters["Name_p0"]);
+
+        Assert.Equal(
+            "SELECT [Users].[Id], [Users].[Name], [Users].[AddressId], [Users].[PhoneId], [Users].[OfficePhoneId], [Users].[Deleted], [Users].[UpdatedAt] " +
+            "FROM [Users] WHERE ([Users].[Name] IN @Name_p0) AND [Users].[Deleted] IS NULL", sqlQuery.GetSql());
+    }
+
+    [Fact]
     public static void NotContainsPredicate()
     {
         var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);


### PR DESCRIPTION
C# 14 binds `array.Contains` to `MemoryExtensions.Contains`, wrapping the collection in an implicit span conversion. The `IN` values resolved to `null`, silently degrading the predicate to `IS NOT NULL`. Unwrap the conversion and pin `LangVersion` to `14.0`.