### PR TITLE
Throw on unsupported Contains collection

### DIFF
--- a/src/SqlGenerator/ExpressionHelper.cs
+++ b/src/SqlGenerator/ExpressionHelper.cs
@@ -180,7 +180,9 @@ internal static class ExpressionHelper
     public static object? GetValuesFromCollection(MethodCallExpression callExpr)
     {
         var collection = callExpr.Method.IsStatic ? callExpr.Arguments.First() : callExpr.Object;
-        var expr = UnwrapSpanConversion(collection) as MemberExpression;
+
+        if (UnwrapSpanConversion(collection) is not MemberExpression expr)
+            throw new NotSupportedException($"'{callExpr.Method.Name}' requires the collection to be a variable, field or property");
 
         try
         {

--- a/tests/SqlGenerator.Tests/MSSQLGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/MSSQLGeneratorTests.cs
@@ -324,6 +324,15 @@ public class MSSQLGeneratorTests
     }
 
     [Fact]
+    public static void ContainsInlineCollectionThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+
+        Assert.Throws<NotSupportedException>(() => sqlGenerator.GetSelectAll(x => new[] { 1, 2, 3 }.Contains(x.Id), null));
+        Assert.Throws<NotSupportedException>(() => sqlGenerator.GetSelectAll(x => new List<int> { 1, 2, 3 }.Contains(x.Id), null));
+    }
+
+    [Fact]
     public static void NotContainsPredicate()
     {
         var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);


### PR DESCRIPTION
`Contains` only supports a variable/field/property collection. An inline literal or method-call result silently produced `WHERE [Col] IS NOT NULL`; now it throws `NotSupportedException`.