### PR TITLE
Throw on unsupported includes

### DIFF
--- a/src/SqlGenerator/ISqlGenerator.cs
+++ b/src/SqlGenerator/ISqlGenerator.cs
@@ -124,11 +124,20 @@ public interface ISqlGenerator<TEntity> where TEntity : class
     /// <summary>
     ///     Get SQL for UPDATE Query
     /// </summary>
+    /// <param name="entity">Entity to update; every mapped column is written</param>
+    /// <param name="includes">Join properties whose rows are updated along with the entity. MySQL only</param>
+    /// <exception cref="ArgumentException">A property in <paramref name="includes" /> isn't marked with a join attribute</exception>
+    /// <exception cref="NotSupportedException">A join would be written for a provider other than MySQL</exception>
     SqlQuery GetUpdate(TEntity entity, params Expression<Func<TEntity, object>>[] includes);
 
     /// <summary>
     ///     Get SQL for UPDATE Query
     /// </summary>
+    /// <param name="predicate">Filter for the rows to update</param>
+    /// <param name="entity">Entity to update; every mapped column is written</param>
+    /// <param name="includes">Join properties whose rows are updated along with the entity. MySQL only</param>
+    /// <exception cref="ArgumentException">A property in <paramref name="includes" /> isn't marked with a join attribute</exception>
+    /// <exception cref="NotSupportedException">A join would be written for a provider other than MySQL</exception>
     SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, TEntity entity, params Expression<Func<TEntity, object>>[] includes);
 
     /// <summary>

--- a/src/SqlGenerator/SqlGenerator.AppendJoin.cs
+++ b/src/SqlGenerator/SqlGenerator.AppendJoin.cs
@@ -14,17 +14,30 @@ namespace MicroOrm.Dapper.Repositories.SqlGenerator;
 public partial class SqlGenerator<TEntity>
     where TEntity : class
 {
+    /// <summary>
+    /// Resolve an "includes" expression to the join property it names
+    /// </summary>
+    private PropertyInfo GetJoinProperty(Expression<Func<TEntity, object>> include, string paramName, out JoinAttributeBase attribute)
+    {
+        var propertyName = ExpressionHelper.GetPropertyName(include);
+
+        var property = AllProperties.FirstOrDefault(q => q.Name == propertyName)
+            ?? throw new ArgumentException($"Can't join [{propertyName}]: not a writable property of {typeof(TEntity).Name}", paramName);
+
+        attribute = property.GetCustomAttribute<JoinAttributeBase>()
+            ?? throw new ArgumentException(
+                $"Can't join [{propertyName}]: property isn't marked with [LeftJoin], [InnerJoin], [RightJoin] or [CrossJoin]", paramName);
+
+        return property;
+    }
+
     private string AppendJoinToUpdate<TBase>(TBase entity, SqlQuery originalBuilder, params Expression<Func<TEntity, object>>[] includes) where TBase : notnull
     {
         var joinBuilder = new StringBuilder();
 
         foreach (var include in includes)
         {
-            var joinProperty = AllProperties.First(q => q.Name == ExpressionHelper.GetPropertyName(include));
-            var attrJoin = joinProperty.GetCustomAttribute<JoinAttributeBase>();
-
-            if (attrJoin == null)
-                continue;
+            var joinProperty = GetJoinProperty(include, nameof(includes), out var attrJoin);
 
             var declaringType = joinProperty.ReflectedType?.GetTypeInfo();
             var tableAttribute = declaringType?.GetCustomAttribute<TableAttribute>();
@@ -35,7 +48,12 @@ public partial class SqlGenerator<TEntity>
 
             var joinEntity = entity.GetType().GetProperty(joinProperty.Name)?.GetValue(entity, null);
             if (joinEntity == null)
-                return string.Empty;
+                continue;
+
+            // "UPDATE t1 JOIN t2 ON ... SET ..." is MySQL-only syntax; every other provider rejects it at parse time
+            if (Provider != SqlProvider.MySQL)
+                throw new NotSupportedException(
+                    $"Update with joins isn't supported for {Provider}, only for MySQL. Update [{joinProperty.Name}] with a separate query");
 
             var dict = properties.ToDictionary(prop => $"{prop.PropertyInfo.ReflectedType?.Name}{prop.PropertyName}",
                 prop => joinType.GetProperty(prop.PropertyName)?.GetValue(joinEntity, null));
@@ -113,11 +131,7 @@ public partial class SqlGenerator<TEntity>
 
         foreach (var include in includes)
         {
-            var joinProperty = AllProperties.First(q => q.Name == ExpressionHelper.GetPropertyName(include));
-            var attrJoin = joinProperty.GetCustomAttribute<JoinAttributeBase>();
-
-            if (attrJoin == null)
-                continue;
+            var joinProperty = GetJoinProperty(include, nameof(includes), out var attrJoin);
 
             var declaringType = joinProperty.ReflectedType?.GetTypeInfo();
             var tableAttribute = declaringType?.GetCustomAttribute<TableAttribute>();

--- a/src/SqlGenerator/SqlGenerator.GetUpdate.cs
+++ b/src/SqlGenerator/SqlGenerator.GetUpdate.cs
@@ -7,11 +7,9 @@ using MicroOrm.Dapper.Repositories.Attributes;
 
 namespace MicroOrm.Dapper.Repositories.SqlGenerator;
 
-
 public partial class SqlGenerator<TEntity>
     where TEntity : class
 {
-
     public virtual SqlQuery GetUpdate(TEntity entity, params Expression<Func<TEntity, object>>[] includes)
     {
         var properties = SqlProperties.Where(p =>
@@ -188,18 +186,12 @@ public partial class SqlGenerator<TEntity>
 
     private string GetFieldsUpdate(string? tableName, IEnumerable<SqlPropertyMetadata> properties, bool useMarks)
     {
-        if (Provider == SqlProvider.SQLite || Provider == SqlProvider.PostgreSQL)
-        {
-            //***
-            //*** Building update query for sqlite
-            //***
-            return string.Join(", ", properties
-                .Select(p => $"{(useMarks ? p.ColumnName : p.CleanColumnName)} = {ParameterSymbol}{p.PropertyInfo.ReflectedType?.Name}{p.PropertyName}"));
-        }
-        else
-        {
-            return string.Join(", ", properties
-                .Select(p => $"{tableName}.{(useMarks ? p.ColumnName : p.CleanColumnName)} = {ParameterSymbol}{p.PropertyInfo.ReflectedType?.Name}{p.PropertyName}"));
-        }
+        return Provider is SqlProvider.SQLite or SqlProvider.PostgreSQL
+            ? string.Join(", ", properties
+                .Select(p =>
+                    $"{(useMarks ? p.ColumnName : p.CleanColumnName)} = {ParameterSymbol}{p.PropertyInfo.ReflectedType?.Name}{p.PropertyName}"))
+            : string.Join(", ", properties
+                .Select(p =>
+                    $"{tableName}.{(useMarks ? p.ColumnName : p.CleanColumnName)} = {ParameterSymbol}{p.PropertyInfo.ReflectedType?.Name}{p.PropertyName}"));
     }
 }

--- a/tests/SqlGenerator.Tests/MSSQLGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/MSSQLGeneratorTests.cs
@@ -819,4 +819,50 @@ public class MSSQLGeneratorTests
         Assert.True("123%" == parameters21["PhonePNumber_p0"].ToString());
         Assert.True("%abc%" == parameters21["Name_p1"].ToString());
     }
+
+    [Fact]
+    public static void UpdateWithNonJoinIncludeThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdate(new User { Id = 10, Name = "John" }, x => x.Name));
+
+        Assert.Contains("Can't join [Name]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateWithPredicateAndNonJoinIncludeThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdate(x => x.Id == 10, new User { Name = "John" }, x => x.Name));
+
+        Assert.Contains("Can't join [Name]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateWithReadOnlyIncludeThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdate(new User { Id = 10, Name = "John" }, x => x.DisplayName));
+
+        Assert.Contains("not a writable property", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateWithJoinThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", Addresses = new Address() };
+        var ex = Assert.Throws<NotSupportedException>(() => sqlGenerator.GetUpdate(user, x => x.Addresses));
+
+        Assert.Contains("only for MySQL", ex.Message);
+    }
+
+    [Fact]
+    public static void SelectWithNonJoinIncludeThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetSelectAll(null, null, x => x.Name));
+
+        Assert.Contains("Can't join [Name]", ex.Message);
+    }
 }

--- a/tests/SqlGenerator.Tests/MySQLGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/MySQLGeneratorTests.cs
@@ -264,14 +264,20 @@ public class MySQLGeneratorTests
     }
 
     [Fact]
-    public static void UpdateWithPredicateAndJoin()
+    public static void SetOrderByAndSetLimitWithWhere()
     {
-        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
-        var model = new User { Addresses = new Address() };
-        var sqlQuery = sqlGenerator.GetUpdate(q => q.AddressId == 1, model, x => x.Addresses);
+        var sqlGenerator = new SqlGenerator<City>(_sqlConnector);
+
+        var filterData = new FilterData
+        {
+            OrderInfo = new OrderInfo { CustomQuery = "Identifier ASC, Name DESC " },
+            LimitInfo = new LimitInfo { Limit = 10, Offset = 2 }
+        };
+
+        var sqlQuery = sqlGenerator.GetSelectAll(q => q.Name != "City", filterData);
         var sql = sqlQuery.GetSql();
         Assert.Equal(
-            "UPDATE Users LEFT JOIN Addresses ON Users.AddressId = Addresses.Id SET Users.Name = @UserName, Users.AddressId = @UserAddressId, Users.PhoneId = @UserPhoneId, Users.OfficePhoneId = @UserOfficePhoneId, Users.Deleted = @UserDeleted, Users.UpdatedAt = @UserUpdatedAt, Addresses.Street = @AddressStreet, Addresses.CityId = @AddressCityId WHERE Users.AddressId = @AddressId_p0",
+            "SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Name != @Name_p0 ORDER BY Identifier ASC, Name DESC LIMIT 10 OFFSET 2",
             sql);
     }
 
@@ -288,20 +294,32 @@ public class MySQLGeneratorTests
     }
 
     [Fact]
-    public static void SetOrderByAndSetLimitWithWhere()
+    public static void UpdateWithPredicateAndJoin()
     {
-        var sqlGenerator = new SqlGenerator<City>(_sqlConnector);
-
-        var filterData = new FilterData
-        {
-            OrderInfo = new OrderInfo { CustomQuery = "Identifier ASC, Name DESC " },
-            LimitInfo = new LimitInfo { Limit = 10, Offset = 2 }
-        };
-
-        var sqlQuery = sqlGenerator.GetSelectAll(q => q.Name != "City", filterData);
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var model = new User { Addresses = new Address() };
+        var sqlQuery = sqlGenerator.GetUpdate(q => q.AddressId == 1, model, x => x.Addresses);
         var sql = sqlQuery.GetSql();
         Assert.Equal(
-            "SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Name != @Name_p0 ORDER BY Identifier ASC, Name DESC LIMIT 10 OFFSET 2",
+            "UPDATE Users LEFT JOIN Addresses ON Users.AddressId = Addresses.Id SET Users.Name = @UserName, Users.AddressId = @UserAddressId, Users.PhoneId = @UserPhoneId, Users.OfficePhoneId = @UserOfficePhoneId, Users.Deleted = @UserDeleted, Users.UpdatedAt = @UserUpdatedAt, Addresses.Street = @AddressStreet, Addresses.CityId = @AddressCityId WHERE Users.AddressId = @AddressId_p0",
             sql);
+    }
+
+    [Fact]
+    public static void UpdateWithNonJoinIncludeThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdate(new User { Id = 10, Name = "John" }, x => x.Name));
+
+        Assert.Contains("Can't join [Name]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateWithReadOnlyIncludeThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdate(new User { Id = 10, Name = "John" }, x => x.DisplayName));
+
+        Assert.Contains("not a writable property", ex.Message);
     }
 }

--- a/tests/SqlGenerator.Tests/OracleGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/OracleGeneratorTests.cs
@@ -652,4 +652,14 @@ public class OracleGeneratorTests
         Assert.Equal("123%", parameters21["PhonePNumber_p0"].ToString());
         Assert.Equal("%abc%", parameters21["Name_p1"].ToString());
     }
+
+    [Fact]
+    public static void UpdateWithJoinThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", Addresses = new Address() };
+        var ex = Assert.Throws<NotSupportedException>(() => sqlGenerator.GetUpdate(user, x => x.Addresses));
+
+        Assert.Contains("only for MySQL", ex.Message);
+    }
 }

--- a/tests/SqlGenerator.Tests/PostgreSQLGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/PostgreSQLGeneratorTests.cs
@@ -171,4 +171,14 @@ public class PostgreSQLGeneratorTests
         Assert.Equal("UPDATE \"DAB\".\"Phones\" SET \"PNumber\" = @PNumber0, \"IsActive\" = @IsActive0, \"Deleted\" = @Deleted0 WHERE \"Id\" = @Id0; " +
                      "UPDATE \"DAB\".\"Phones\" SET \"PNumber\" = @PNumber1, \"IsActive\" = @IsActive1, \"Deleted\" = @Deleted1 WHERE \"Id\" = @Id1", sqlQuery.GetSql());
     }
+
+    [Fact]
+    public static void UpdateWithJoinThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", Addresses = new Address() };
+        var ex = Assert.Throws<NotSupportedException>(() => sqlGenerator.GetUpdate(user, x => x.Addresses));
+
+        Assert.Contains("only for MySQL", ex.Message);
+    }
 }

--- a/tests/SqlGenerator.Tests/SQLiteGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/SQLiteGeneratorTests.cs
@@ -54,4 +54,14 @@ public class SQLiteGeneratorTests
         Assert.Equal("SELECT Cities.Identifier, Cities.Name FROM Cities WHERE Cities.Identifier = @Identifier_p0 AND Cities.Name = @Name_p1 LIMIT 1",
             sqlQuery.GetSql());
     }
+
+    [Fact]
+    public static void UpdateWithJoinThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", Addresses = new Address() };
+        var ex = Assert.Throws<NotSupportedException>(() => sqlGenerator.GetUpdate(user, x => x.Addresses));
+
+        Assert.Contains("only for MySQL", ex.Message);
+    }
 }

--- a/tests/TestClasses/User.cs
+++ b/tests/TestClasses/User.cs
@@ -13,6 +13,9 @@ public class User : BaseEntity<int>
     [Column(Order = 1)]
     public string Name { get; set; }
 
+    // Read-only, so it's never mapped to a column
+    public string DisplayName => $"{Name} #{Id}";
+
     public int AddressId { get; set; }
 
     public int PhoneId { get; set; }


### PR DESCRIPTION
An `includes` expression now has to name a property marked with a join attribute, and anything else raises an `ArgumentException` naming the property rather than being silently dropped from the query. Update with joins is also rejected for every provider except MySQL, since `UPDATE t1 JOIN t2 ON ... SET ...` is MySQL syntax that SQL Server, PostgreSQL, Oracle and SQLite all refuse to parse. Passing a join whose navigation property is null still works and simply skips that join, so nothing that generates valid SQL today starts throwing.

Ref #581
