### PR TITLE
Add UpdateColumns for partial updates

### DIFF
--- a/src/DapperRepository.UpdateColumns.cs
+++ b/src/DapperRepository.UpdateColumns.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Data;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Dapper;
+
+namespace MicroOrm.Dapper.Repositories;
+
+/// <summary>
+///     Base Repository
+/// </summary>
+public partial class DapperRepository<TEntity>
+    where TEntity : class
+{
+    public virtual bool UpdateColumns(TEntity instance, Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns)
+    {
+        return UpdateColumns(instance, null, column, columns);
+    }
+
+    public virtual Task<bool> UpdateColumnsAsync(TEntity instance, Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns)
+    {
+        return UpdateColumnsAsync(instance, null, CancellationToken.None, column, columns);
+    }
+
+    public virtual Task<bool> UpdateColumnsAsync(TEntity instance, CancellationToken cancellationToken, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns)
+    {
+        return UpdateColumnsAsync(instance, null, cancellationToken, column, columns);
+    }
+
+    public virtual bool UpdateColumns(TEntity instance, IDbTransaction? transaction, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns)
+    {
+        var sqlQuery = SqlGenerator.GetUpdateColumns(instance, column, columns);
+        var updated = Connection.Execute(sqlQuery.GetSql(), sqlQuery.Param, transaction) > 0;
+        return updated;
+    }
+
+    public virtual Task<bool> UpdateColumnsAsync(TEntity instance, IDbTransaction? transaction, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns)
+    {
+        return UpdateColumnsAsync(instance, transaction, CancellationToken.None, column, columns);
+    }
+
+    public virtual async Task<bool> UpdateColumnsAsync(TEntity instance, IDbTransaction? transaction, CancellationToken cancellationToken,
+        Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns)
+    {
+        var sqlQuery = SqlGenerator.GetUpdateColumns(instance, column, columns);
+        var updated = await Connection.ExecuteAsync(new CommandDefinition(sqlQuery.GetSql(), sqlQuery.Param, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false) > 0;
+        return updated;
+    }
+
+    public virtual bool UpdateColumns(Expression<Func<TEntity, bool>>? predicate, TEntity instance, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns)
+    {
+        return UpdateColumns(predicate, instance, null, column, columns);
+    }
+
+    public virtual Task<bool> UpdateColumnsAsync(Expression<Func<TEntity, bool>>? predicate, TEntity instance, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns)
+    {
+        return UpdateColumnsAsync(predicate, instance, CancellationToken.None, column, columns);
+    }
+
+    public virtual Task<bool> UpdateColumnsAsync(Expression<Func<TEntity, bool>>? predicate, TEntity instance, CancellationToken cancellationToken,
+        Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns)
+    {
+        return UpdateColumnsAsync(predicate, instance, null, cancellationToken, column, columns);
+    }
+
+    public virtual bool UpdateColumns(Expression<Func<TEntity, bool>>? predicate, TEntity instance, IDbTransaction? transaction,
+        Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns)
+    {
+        var sqlQuery = SqlGenerator.GetUpdateColumns(predicate, instance, column, columns);
+        var updated = Connection.Execute(sqlQuery.GetSql(), sqlQuery.Param, transaction) > 0;
+        return updated;
+    }
+
+    public virtual Task<bool> UpdateColumnsAsync(Expression<Func<TEntity, bool>>? predicate, TEntity instance, IDbTransaction? transaction,
+        Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns)
+    {
+        return UpdateColumnsAsync(predicate, instance, transaction, CancellationToken.None, column, columns);
+    }
+
+    public virtual async Task<bool> UpdateColumnsAsync(Expression<Func<TEntity, bool>>? predicate, TEntity instance, IDbTransaction? transaction,
+        CancellationToken cancellationToken, Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns)
+    {
+        var sqlQuery = SqlGenerator.GetUpdateColumns(predicate, instance, column, columns);
+        var updated = await Connection.ExecuteAsync(new CommandDefinition(sqlQuery.GetSql(), sqlQuery.Param, transaction, cancellationToken: cancellationToken)).ConfigureAwait(false) > 0;
+        return updated;
+    }
+}

--- a/src/IDapperRepository.cs
+++ b/src/IDapperRepository.cs
@@ -196,6 +196,76 @@ public interface IDapperRepository<TEntity> : IReadOnlyDapperRepository<TEntity>
         params Expression<Func<TEntity, object>>[] includes);
 
     /// <summary>
+    ///     Update the listed columns of the object in DB
+    /// </summary>
+    bool UpdateColumns(TEntity instance, Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the object in DB
+    /// </summary>
+    Task<bool> UpdateColumnsAsync(TEntity instance, Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the object in DB
+    /// </summary>
+    Task<bool> UpdateColumnsAsync(TEntity instance, CancellationToken cancellationToken, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the object in DB
+    /// </summary>
+    bool UpdateColumns(TEntity instance, IDbTransaction? transaction, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the object in DB
+    /// </summary>
+    Task<bool> UpdateColumnsAsync(TEntity instance, IDbTransaction? transaction, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the object in DB
+    /// </summary>
+    Task<bool> UpdateColumnsAsync(TEntity instance, IDbTransaction? transaction, CancellationToken cancellationToken, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the objects matched by the predicate
+    /// </summary>
+    bool UpdateColumns(Expression<Func<TEntity, bool>>? predicate, TEntity instance, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the objects matched by the predicate
+    /// </summary>
+    Task<bool> UpdateColumnsAsync(Expression<Func<TEntity, bool>>? predicate, TEntity instance, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the objects matched by the predicate
+    /// </summary>
+    Task<bool> UpdateColumnsAsync(Expression<Func<TEntity, bool>>? predicate, TEntity instance, CancellationToken cancellationToken,
+        Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the objects matched by the predicate
+    /// </summary>
+    bool UpdateColumns(Expression<Func<TEntity, bool>>? predicate, TEntity instance, IDbTransaction? transaction, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the objects matched by the predicate
+    /// </summary>
+    Task<bool> UpdateColumnsAsync(Expression<Func<TEntity, bool>>? predicate, TEntity instance, IDbTransaction? transaction,
+        Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Update the listed columns of the objects matched by the predicate
+    /// </summary>
+    Task<bool> UpdateColumnsAsync(Expression<Func<TEntity, bool>>? predicate, TEntity instance, IDbTransaction? transaction, CancellationToken cancellationToken,
+        Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
     ///     Bulk Update objects to DB
     /// </summary>
     bool BulkUpdate(IEnumerable<TEntity> instances);

--- a/src/SqlGenerator/ISqlGenerator.cs
+++ b/src/SqlGenerator/ISqlGenerator.cs
@@ -141,19 +141,39 @@ public interface ISqlGenerator<TEntity> where TEntity : class
     SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, TEntity entity, params Expression<Func<TEntity, object>>[] includes);
 
     /// <summary>
+    ///     Get SQL for UPDATE Query of the listed columns only
+    /// </summary>
+    /// <param name="entity">Entity the values are read from; rows are matched by [Key]</param>
+    /// <param name="column">Column to update</param>
+    /// <param name="columns">More columns to update</param>
+    /// <exception cref="ArgumentException">A column isn't mapped, or is marked with [Key] or [IgnoreUpdate]</exception>
+    SqlQuery GetUpdateColumns(TEntity entity, Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
+    ///     Get SQL for UPDATE Query of the listed columns only
+    /// </summary>
+    /// <param name="predicate">Filter for the rows to update</param>
+    /// <param name="entity">Entity the values are read from</param>
+    /// <param name="column">Column to update</param>
+    /// <param name="columns">More columns to update</param>
+    /// <exception cref="ArgumentException">A column isn't mapped, or is marked with [Key] or [IgnoreUpdate]</exception>
+    SqlQuery GetUpdateColumns(Expression<Func<TEntity, bool>>? predicate, TEntity entity, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns);
+
+    /// <summary>
     ///     Get the SQL statement to update the fields under the anonymous class
     ///     (Filtering fields in anonymous classes that are inconsistent with the entity type)
     /// </summary>
-    /// <param name="predicate"></param>
-    /// <param name="setPropertyObj"></param>
+    /// <param name="predicate">Filter for the rows to update</param>
+    /// <param name="setPropertyObj">Object whose properties name the columns to update and hold their values</param>
     SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, object setPropertyObj);
 
     /// <summary>
     ///     Get the SQL statement to update the fields in the setPropertyDict dictionary
     ///     (Validates fields in the dictionary that are inconsistent with the entity type)
     /// </summary>
-    /// <param name="predicate"></param>
-    /// <param name="setPropertyDict"></param>
+    /// <param name="predicate">Filter for the rows to update</param>
+    /// <param name="setPropertyDict">Columns to update and their values</param>
     SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, Dictionary<string, object> setPropertyDict);
 
     /// <summary>

--- a/src/SqlGenerator/SqlGenerator.GetBulkInsert.cs
+++ b/src/SqlGenerator/SqlGenerator.GetBulkInsert.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using MicroOrm.Dapper.Repositories.Attributes;
 
 namespace MicroOrm.Dapper.Repositories.SqlGenerator;
 
@@ -32,18 +30,7 @@ public partial class SqlGenerator<TEntity>
         for (var i = 0; i < entitiesArray.Length; i++)
         {
             var entity = entitiesArray[i];
-            if (HasUpdatedAt && UpdatedAtProperty.GetCustomAttribute<UpdatedAtAttribute>() is { } attribute)
-            {
-                var offset = attribute.TimeKind == DateTimeKind.Local
-                    ? new DateTimeOffset(DateTime.Now)
-                    : new DateTimeOffset(DateTime.UtcNow);
-                if (attribute.OffSet != 0)
-                {
-                    offset = offset.ToOffset(TimeSpan.FromHours(attribute.OffSet));
-                }
-
-                UpdatedAtProperty.SetValue(entity, offset.DateTime);
-            }
+            SetUpdatedAt(entity);
 
             foreach (var property in properties)
                 parameters.Add(property.PropertyName + i, entityType.GetProperty(property.PropertyName)?.GetValue(entity, null));

--- a/src/SqlGenerator/SqlGenerator.GetBulkUpdate.cs
+++ b/src/SqlGenerator/SqlGenerator.GetBulkUpdate.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using MicroOrm.Dapper.Repositories.Attributes;
 
 namespace MicroOrm.Dapper.Repositories.SqlGenerator;
 
@@ -32,18 +30,7 @@ public partial class SqlGenerator<TEntity>
         for (var i = 0; i < entitiesArray.Length; i++)
         {
             var entity = entitiesArray[i];
-            if (HasUpdatedAt && UpdatedAtProperty.GetCustomAttribute<UpdatedAtAttribute>() is { } attribute)
-            {
-                var offset = attribute.TimeKind == DateTimeKind.Local
-                    ? new DateTimeOffset(DateTime.Now)
-                    : new DateTimeOffset(DateTime.UtcNow);
-                if (attribute.OffSet != 0)
-                {
-                    offset = offset.ToOffset(TimeSpan.FromHours(attribute.OffSet));
-                }
-
-                UpdatedAtProperty.SetValue(entity, offset.DateTime);
-            }
+            SetUpdatedAt(entity);
 
             if (Provider != SqlProvider.Oracle)
             {

--- a/src/SqlGenerator/SqlGenerator.GetDelete.cs
+++ b/src/SqlGenerator/SqlGenerator.GetDelete.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
-using MicroOrm.Dapper.Repositories.Attributes;
 
 namespace MicroOrm.Dapper.Repositories.SqlGenerator;
 
@@ -35,17 +33,9 @@ public partial class SqlGenerator<TEntity>
                 .Append(" = ")
                 .Append(LogicalDeleteValue);
 
-            if (HasUpdatedAt && UpdatedAtProperty.GetCustomAttribute<UpdatedAtAttribute>() is { } attribute)
+            if (HasUpdatedAt)
             {
-                var offset = attribute.TimeKind == DateTimeKind.Local
-                    ? new DateTimeOffset(DateTime.Now)
-                    : new DateTimeOffset(DateTime.UtcNow);
-                if (attribute.OffSet != 0)
-                {
-                    offset = offset.ToOffset(TimeSpan.FromHours(attribute.OffSet));
-                }
-
-                UpdatedAtProperty.SetValue(entity, offset.DateTime);
+                SetUpdatedAt(entity);
 
                 sqlQuery.SqlBuilder
                     .Append(", ")

--- a/src/SqlGenerator/SqlGenerator.GetInsert.cs
+++ b/src/SqlGenerator/SqlGenerator.GetInsert.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Linq;
-using System.Reflection;
 using Dapper;
-using MicroOrm.Dapper.Repositories.Attributes;
 using MicroOrm.Dapper.Repositories.Extensions;
 
 namespace MicroOrm.Dapper.Repositories.SqlGenerator;
@@ -19,18 +17,7 @@ public partial class SqlGenerator<TEntity>
                 ? SqlProperties.Where(p => !p.PropertyName.Equals(IdentitySqlProperty.PropertyName, StringComparison.OrdinalIgnoreCase))
                 : SqlProperties).ToList();
 
-        if (HasUpdatedAt && UpdatedAtProperty.GetCustomAttribute<UpdatedAtAttribute>() is { } attribute)
-        {
-            var offset = attribute.TimeKind == DateTimeKind.Local
-                ? new DateTimeOffset(DateTime.Now)
-                : new DateTimeOffset(DateTime.UtcNow);
-            if (attribute.OffSet != 0)
-            {
-                offset = offset.ToOffset(TimeSpan.FromHours(attribute.OffSet));
-            }
-
-            UpdatedAtProperty.SetValue(entity, offset.DateTime);
-        }
+        SetUpdatedAt(entity);
 
         var query = new SqlQuery(entity);
 

--- a/src/SqlGenerator/SqlGenerator.GetUpdate.cs
+++ b/src/SqlGenerator/SqlGenerator.GetUpdate.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
-using MicroOrm.Dapper.Repositories.Attributes;
 
 namespace MicroOrm.Dapper.Repositories.SqlGenerator;
 
@@ -12,44 +10,167 @@ public partial class SqlGenerator<TEntity>
 {
     public virtual SqlQuery GetUpdate(TEntity entity, params Expression<Func<TEntity, object>>[] includes)
     {
-        var properties = SqlProperties.Where(p =>
-            !KeySqlProperties.Any(k => k.PropertyName.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)) && !p.IgnoreUpdate).ToArray();
+        var properties = GetPropertiesToUpdate();
 
         if (properties.Length == 0)
             throw new ArgumentException("Can't update without [Key]");
 
-        if (HasUpdatedAt && UpdatedAtProperty.GetCustomAttribute<UpdatedAtAttribute>() is { } attribute)
-        {
-            var offset = attribute.TimeKind == DateTimeKind.Local
-                ? new DateTimeOffset(DateTime.Now)
-                : new DateTimeOffset(DateTime.UtcNow);
-            if (attribute.OffSet != 0)
-            {
-                offset = offset.ToOffset(TimeSpan.FromHours(attribute.OffSet));
-            }
+        SetUpdatedAt(entity);
 
-            UpdatedAtProperty.SetValue(entity, offset.DateTime);
-        }
+        return BuildUpdateByKey(entity, properties, includes);
+    }
+
+    public virtual SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, TEntity entity, params Expression<Func<TEntity, object>>[] includes)
+    {
+        var properties = GetPropertiesToUpdate();
+
+        SetUpdatedAt(entity);
+
+        return BuildUpdateByPredicate(predicate, entity, properties, includes);
+    }
+
+    public virtual SqlQuery GetUpdateColumns(TEntity entity, Expression<Func<TEntity, object>> column, params Expression<Func<TEntity, object>>[] columns)
+    {
+        var properties = GetColumnsToUpdate(column, columns);
+
+        SetUpdatedAt(entity);
+
+        return BuildUpdateByKey(entity, properties, []);
+    }
+
+    public virtual SqlQuery GetUpdateColumns(Expression<Func<TEntity, bool>>? predicate, TEntity entity, Expression<Func<TEntity, object>> column,
+        params Expression<Func<TEntity, object>>[] columns)
+    {
+        var properties = GetColumnsToUpdate(column, columns);
+
+        SetUpdatedAt(entity);
+
+        return BuildUpdateByPredicate(predicate, entity, properties, []);
+    }
+
+    public virtual SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, object setPropertyObj)
+    {
+        var setProperties = setPropertyObj.GetType().GetProperties();
+        var properties = SqlProperties
+            .Where(p => !KeySqlProperties.Any(k => k.PropertyName.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)) && !p.IgnoreUpdate
+                && setProperties.Any(k => k.Name.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+
+        var updatedAt = GetUpdatedAtToSet(properties, out var updatedAtValue);
+        var fields = properties;
+        if (updatedAt != null)
+            fields = [.. properties, updatedAt];
 
         var query = new SqlQuery();
-
         query.SqlBuilder
             .Append("UPDATE ")
             .Append(TableName)
             .Append(' ');
+        query.SqlBuilder.Append("SET ");
+        query.SqlBuilder.Append(GetFieldsUpdate(TableName, fields, UseQuotationMarks == true));
+        query.SqlBuilder.Append(' ');
+        AppendWherePredicateQuery(query, predicate, QueryType.Update);
 
-        if (includes.Length > 0)
+        var parameters = (Dictionary<string, object?>)query.Param!;
+        foreach (var metadata in properties)
         {
-            var joinsBuilder = AppendJoinToUpdate(entity, query, includes);
-            query.SqlBuilder.Append("SET ");
-            query.SqlBuilder.Append(GetFieldsUpdate(TableName, properties, UseQuotationMarks == true));
-            query.SqlBuilder.Append(joinsBuilder);
+            var setProp = setProperties.FirstOrDefault(p => p.Name.Equals(metadata.PropertyName, StringComparison.OrdinalIgnoreCase));
+            if (setProp == null)
+                continue;
+            parameters.Add($"{typeof(TEntity).Name}{metadata.PropertyName}", setProp.GetValue(setPropertyObj));
         }
-        else
+
+        if (updatedAt != null)
+            parameters.Add($"{typeof(TEntity).Name}{updatedAt.PropertyName}", updatedAtValue);
+
+        return query;
+    }
+
+    public virtual SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, Dictionary<string, object> setPropertyDict)
+    {
+        var propNameExceptItems = setPropertyDict.Keys.Except(SqlProperties.Select(p => p.PropertyName)).ToArray();
+        if (propNameExceptItems.Length > 0)
         {
-            query.SqlBuilder.Append("SET ");
-            query.SqlBuilder.Append(GetFieldsUpdate(TableName, properties, UseQuotationMarks == true));
+            string keys = string.Join(",", propNameExceptItems);
+            throw new ArgumentException(string.Concat(nameof(setPropertyDict), "content error detail:", $" [{keys}] not equal entity column name"));
         }
+
+        var properties = SqlProperties
+            .Where(p => !KeySqlProperties.Any(k => k.PropertyName.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)) && !p.IgnoreUpdate
+                && setPropertyDict.Any(k => k.Key.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)))
+            .ToArray();
+
+        var updatedAt = GetUpdatedAtToSet(properties, out var updatedAtValue);
+        var fields = properties;
+        if (updatedAt != null)
+            fields = [.. properties, updatedAt];
+
+        var query = new SqlQuery();
+        query.SqlBuilder
+            .Append("UPDATE ")
+            .Append(TableName)
+            .Append(' ');
+        query.SqlBuilder.Append("SET ");
+        query.SqlBuilder.Append(GetFieldsUpdate(TableName, fields, UseQuotationMarks == true));
+        query.SqlBuilder.Append(' ');
+        AppendWherePredicateQuery(query, predicate, QueryType.Update);
+
+        var parameters = (Dictionary<string, object?>)query.Param!;
+        foreach (var metadata in properties)
+        {
+            var value = setPropertyDict.FirstOrDefault(p => p.Key.Equals(metadata.PropertyName, StringComparison.OrdinalIgnoreCase)).Value;
+            parameters.Add($"{typeof(TEntity).Name}{metadata.PropertyName}", value);
+        }
+
+        if (updatedAt != null)
+            parameters.Add($"{typeof(TEntity).Name}{updatedAt.PropertyName}", updatedAtValue);
+
+        return query;
+    }
+
+    private SqlPropertyMetadata[] GetPropertiesToUpdate()
+    {
+        return SqlProperties.Where(p =>
+            !KeySqlProperties.Any(k => k.PropertyName.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)) && !p.IgnoreUpdate).ToArray();
+    }
+
+    private SqlPropertyMetadata[] GetColumnsToUpdate(Expression<Func<TEntity, object>> column, Expression<Func<TEntity, object>>[] columns)
+    {
+        var properties = new List<SqlPropertyMetadata>(columns.Length + 1);
+
+        AddColumnToUpdate(properties, column, nameof(column));
+        foreach (var item in columns)
+            AddColumnToUpdate(properties, item, nameof(columns));
+
+        var updatedAt = GetUpdatedAtToSet(properties, out _);
+        if (updatedAt != null)
+            properties.Add(updatedAt);
+
+        return properties.ToArray();
+    }
+
+    private void AddColumnToUpdate(List<SqlPropertyMetadata> properties, Expression<Func<TEntity, object>> column, string paramName)
+    {
+        var propertyName = ExpressionHelper.GetPropertyName(column);
+
+        var property = SqlProperties.FirstOrDefault(p => p.PropertyName == propertyName)
+            ?? throw new ArgumentException($"Can't update [{propertyName}]: not a mapped column of {typeof(TEntity).Name}", paramName);
+
+        if (KeySqlProperties.Any(k => k.PropertyName == propertyName))
+            throw new ArgumentException($"Can't update [{propertyName}]: property is marked with [Key]", paramName);
+
+        if (property.IgnoreUpdate)
+            throw new ArgumentException($"Can't update [{propertyName}]: property is marked with [IgnoreUpdate]", paramName);
+
+        if (properties.All(p => p.PropertyName != propertyName))
+            properties.Add(property);
+    }
+
+    private SqlQuery BuildUpdateByKey(TEntity entity, SqlPropertyMetadata[] properties, Expression<Func<TEntity, object>>[] includes)
+    {
+        var query = new SqlQuery();
+
+        AppendUpdateSet(query, entity, properties, includes);
 
         query.SqlBuilder.Append(" WHERE ");
 
@@ -67,44 +188,12 @@ public partial class SqlGenerator<TEntity>
         return query;
     }
 
-
-    public virtual SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, TEntity entity, params Expression<Func<TEntity, object>>[] includes)
+    private SqlQuery BuildUpdateByPredicate(Expression<Func<TEntity, bool>>? predicate, TEntity entity, SqlPropertyMetadata[] properties,
+        Expression<Func<TEntity, object>>[] includes)
     {
-        var properties = SqlProperties.Where(p =>
-            !KeySqlProperties.Any(k => k.PropertyName.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)) && !p.IgnoreUpdate).ToArray();
-
-        if (HasUpdatedAt && UpdatedAtProperty.GetCustomAttribute<UpdatedAtAttribute>() is { } attribute)
-        {
-            var offset = attribute.TimeKind == DateTimeKind.Local
-                ? new DateTimeOffset(DateTime.Now)
-                : new DateTimeOffset(DateTime.UtcNow);
-            if (attribute.OffSet != 0)
-            {
-                offset = offset.ToOffset(TimeSpan.FromHours(attribute.OffSet));
-            }
-
-            UpdatedAtProperty.SetValue(entity, offset.DateTime);
-        }
-
         var query = new SqlQuery();
 
-        query.SqlBuilder
-            .Append("UPDATE ")
-            .Append(TableName)
-            .Append(' ');
-
-        if (includes.Length > 0)
-        {
-            var joinsBuilder = AppendJoinToUpdate(entity, query, includes);
-            query.SqlBuilder.Append("SET ");
-            query.SqlBuilder.Append(GetFieldsUpdate(TableName, properties, UseQuotationMarks == true));
-            query.SqlBuilder.Append(joinsBuilder);
-        }
-        else
-        {
-            query.SqlBuilder.Append("SET ");
-            query.SqlBuilder.Append(GetFieldsUpdate(TableName, properties, UseQuotationMarks == true));
-        }
+        AppendUpdateSet(query, entity, properties, includes);
 
         query.SqlBuilder
             .Append(' ');
@@ -118,70 +207,18 @@ public partial class SqlGenerator<TEntity>
         return query;
     }
 
-
-    public virtual SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, object setPropertyObj)
+    private void AppendUpdateSet(SqlQuery query, TEntity entity, SqlPropertyMetadata[] properties, Expression<Func<TEntity, object>>[] includes)
     {
-        var setProperties = setPropertyObj.GetType().GetProperties();
-        var properties = SqlProperties
-            .Where(p => !KeySqlProperties.Any(k => k.PropertyName.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)) && !p.IgnoreUpdate
-                && setProperties.Any(k => k.Name.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)))
-            .ToArray();
-
-        var query = new SqlQuery();
         query.SqlBuilder
             .Append("UPDATE ")
             .Append(TableName)
             .Append(' ');
+
+        var joinsBuilder = includes.Length > 0 ? AppendJoinToUpdate(entity, query, includes) : string.Empty;
+
         query.SqlBuilder.Append("SET ");
         query.SqlBuilder.Append(GetFieldsUpdate(TableName, properties, UseQuotationMarks == true));
-        query.SqlBuilder.Append(' ');
-        AppendWherePredicateQuery(query, predicate, QueryType.Update);
-
-        var parameters = (Dictionary<string, object?>)query.Param!;
-        foreach (var metadata in properties)
-        {
-            var setProp = setProperties.FirstOrDefault(p => p.Name.Equals(metadata.PropertyName, StringComparison.OrdinalIgnoreCase));
-            if (setProp == null)
-                continue;
-            parameters.Add($"{typeof(TEntity).Name}{metadata.PropertyName}", setProp.GetValue(setPropertyObj));
-        }
-
-        return query;
-    }
-
-
-    public virtual SqlQuery GetUpdate(Expression<Func<TEntity, bool>>? predicate, Dictionary<string, object> setPropertyDict)
-    {
-        var propNameExceptItems = setPropertyDict.Keys.Except(SqlProperties.Select(p => p.PropertyName)).ToArray();
-        if (propNameExceptItems.Length > 0)
-        {
-            string keys = string.Join(",", propNameExceptItems);
-            throw new ArgumentException(string.Concat(nameof(setPropertyDict), "content error detail:", $" [{keys}] not equal entity column name"));
-        }
-
-        var properties = SqlProperties
-            .Where(p => !KeySqlProperties.Any(k => k.PropertyName.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)) && !p.IgnoreUpdate
-                && setPropertyDict.Any(k => k.Key.Equals(p.PropertyName, StringComparison.OrdinalIgnoreCase)))
-            .ToArray();
-
-        var query = new SqlQuery();
-        query.SqlBuilder
-            .Append("UPDATE ")
-            .Append(TableName)
-            .Append(' ');
-        query.SqlBuilder.Append("SET ");
-        query.SqlBuilder.Append(GetFieldsUpdate(TableName, properties, UseQuotationMarks == true));
-        query.SqlBuilder.Append(' ');
-        AppendWherePredicateQuery(query, predicate, QueryType.Update);
-
-        var parameters = (Dictionary<string, object?>)query.Param!;
-        foreach (var metadata in properties)
-        {
-            var value = setPropertyDict.FirstOrDefault(p => p.Key.Equals(metadata.PropertyName, StringComparison.OrdinalIgnoreCase)).Value;
-            parameters.Add($"{typeof(TEntity).Name}{metadata.PropertyName}", value);
-        }
-
-        return query;
+        query.SqlBuilder.Append(joinsBuilder);
     }
 
     private string GetFieldsUpdate(string? tableName, IEnumerable<SqlPropertyMetadata> properties, bool useMarks)

--- a/src/SqlGenerator/SqlGenerator.UpdatedAt.cs
+++ b/src/SqlGenerator/SqlGenerator.UpdatedAt.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using MicroOrm.Dapper.Repositories.Attributes;
+
+namespace MicroOrm.Dapper.Repositories.SqlGenerator;
+
+public partial class SqlGenerator<TEntity>
+    where TEntity : class
+{
+    /// <summary>
+    /// Write the current time to the [UpdatedAt] property of the entity
+    /// </summary>
+    private void SetUpdatedAt(object entity)
+    {
+        if (HasUpdatedAt && UpdatedAtProperty.GetCustomAttribute<UpdatedAtAttribute>() is { } attribute)
+            UpdatedAtProperty.SetValue(entity, GetUpdatedAtValue(attribute));
+    }
+
+    /// <summary>
+    /// Get the [UpdatedAt] column and its value when it isn't among the columns already being set, otherwise null
+    /// </summary>
+    private SqlPropertyMetadata? GetUpdatedAtToSet(IEnumerable<SqlPropertyMetadata> properties, out DateTime value)
+    {
+        value = default;
+
+        if (!HasUpdatedAt || UpdatedAtProperty.GetCustomAttribute<UpdatedAtAttribute>() is not { } attribute)
+            return null;
+
+        // The metadata of SqlProperties is the configured one, UpdatedAtPropertyMetadata keeps the raw column name
+        var metadata = SqlProperties.FirstOrDefault(p => p.PropertyName.Equals(UpdatedAtProperty.Name, StringComparison.OrdinalIgnoreCase));
+        if (metadata == null || metadata.IgnoreUpdate)
+            return null;
+
+        if (properties.Any(p => p.PropertyName.Equals(metadata.PropertyName, StringComparison.OrdinalIgnoreCase)))
+            return null;
+
+        value = GetUpdatedAtValue(attribute);
+        return metadata;
+    }
+
+    private static DateTime GetUpdatedAtValue(UpdatedAtAttribute attribute)
+    {
+        var offset = attribute.TimeKind == DateTimeKind.Local
+            ? new DateTimeOffset(DateTime.Now)
+            : new DateTimeOffset(DateTime.UtcNow);
+
+        if (attribute.OffSet != 0)
+            offset = offset.ToOffset(TimeSpan.FromHours(attribute.OffSet));
+
+        return offset.DateTime;
+    }
+}

--- a/tests/Repositories.Base/BaseRepositoriesTests.cs
+++ b/tests/Repositories.Base/BaseRepositoriesTests.cs
@@ -418,6 +418,68 @@ public abstract class BaseRepositoriesTests
     }
 
     [Fact]
+    public void InsertAndUpdateColumns()
+    {
+        var user = new User
+        {
+            Name = "John",
+            AddressId = 100
+        };
+
+        var insert = Db.Users.Insert(user);
+        Assert.True(insert);
+
+        var insertedAt = Db.Users.Find(q => q.Id == user.Id).UpdatedAt;
+        user.Name = "John1";
+        user.AddressId = 200;
+
+        var update = Db.Users.UpdateColumns(user, x => x.Name);
+        Assert.True(update);
+
+        var userFromDb = Db.Users.Find(q => q.Id == user.Id);
+        Assert.Equal("John1", userFromDb.Name);
+        Assert.Equal(100, userFromDb.AddressId);
+        Assert.True(userFromDb.UpdatedAt >= insertedAt);
+
+        update = Db.Users.UpdateColumns(q => q.Id == user.Id, user, x => x.AddressId);
+        Assert.True(update);
+
+        userFromDb = Db.Users.Find(q => q.Id == user.Id);
+        Assert.Equal(200, userFromDb.AddressId);
+    }
+
+    [Fact]
+    public async Task InsertAndUpdateColumnsAsync()
+    {
+        var user = new User
+        {
+            Name = "John",
+            AddressId = 100
+        };
+
+        var insert = await Db.Users.InsertAsync(user, TestContext.Current.CancellationToken);
+        Assert.True(insert);
+
+        var insertedAt = (await Db.Users.FindAsync(q => q.Id == user.Id, TestContext.Current.CancellationToken)).UpdatedAt;
+        user.Name = "John1";
+        user.AddressId = 200;
+
+        var update = await Db.Users.UpdateColumnsAsync(user, TestContext.Current.CancellationToken, x => x.Name);
+        Assert.True(update);
+
+        var userFromDb = await Db.Users.FindAsync(q => q.Id == user.Id, TestContext.Current.CancellationToken);
+        Assert.Equal("John1", userFromDb.Name);
+        Assert.Equal(100, userFromDb.AddressId);
+        Assert.True(userFromDb.UpdatedAt >= insertedAt);
+
+        update = await Db.Users.UpdateColumnsAsync(q => q.Id == user.Id, user, TestContext.Current.CancellationToken, x => x.AddressId);
+        Assert.True(update);
+
+        userFromDb = await Db.Users.FindAsync(q => q.Id == user.Id, TestContext.Current.CancellationToken);
+        Assert.Equal(200, userFromDb.AddressId);
+    }
+
+    [Fact]
     public void InsertBinaryData()
     {
         var guid = Guid.NewGuid();

--- a/tests/SqlGenerator.Tests/MSSQLGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/MSSQLGeneratorTests.cs
@@ -865,4 +865,100 @@ public class MSSQLGeneratorTests
 
         Assert.Contains("Can't join [Name]", ex.Message);
     }
+
+    [Fact]
+    public static void UpdateColumns()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(user, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+        Assert.NotNull(user.UpdatedAt);
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.Equal(3, parameters.Count);
+        Assert.Equal("John", parameters["UserName"]);
+        Assert.Equal(10, parameters["UserId"]);
+    }
+
+    [Fact]
+    public static void UpdateColumns_QuoMarks()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name);
+
+        Assert.Equal("UPDATE [Users] SET [Users].[Name] = @UserName, [Users].[UpdatedAt] = @UserUpdatedAt WHERE [Users].[Id] = @UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithPredicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(x => x.Id == 10, user, x => x.Name, x => x.AddressId);
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.AddressId = @UserAddressId, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0",
+            sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithDuplicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithKeyThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Id));
+
+        Assert.Contains("Can't update [Id]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithIgnoreUpdateThrows()
+    {
+        var sqlGenerator = new SqlGenerator<Phone>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new Phone { Id = 10, Code = "ZZZ" }, x => x.Code));
+
+        Assert.Contains("[IgnoreUpdate]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithReadOnlyColumnThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.DisplayName));
+
+        Assert.Contains("not a mapped column", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateAnonymousWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new { Name = "John" });
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
+
+    [Fact]
+    public static void UpdateDictionaryWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new Dictionary<string, object> { { "Name", "John" } });
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
 }

--- a/tests/SqlGenerator.Tests/MySQLGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/MySQLGeneratorTests.cs
@@ -322,4 +322,100 @@ public class MySQLGeneratorTests
 
         Assert.Contains("not a writable property", ex.Message);
     }
+
+    [Fact]
+    public static void UpdateColumns()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(user, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+        Assert.NotNull(user.UpdatedAt);
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.Equal(3, parameters.Count);
+        Assert.Equal("John", parameters["UserName"]);
+        Assert.Equal(10, parameters["UserId"]);
+    }
+
+    [Fact]
+    public static void UpdateColumns_QuoMarks()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name);
+
+        Assert.Equal("UPDATE `Users` SET `Users`.`Name` = @UserName, `Users`.`UpdatedAt` = @UserUpdatedAt WHERE `Users`.`Id` = @UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithPredicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(x => x.Id == 10, user, x => x.Name, x => x.AddressId);
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.AddressId = @UserAddressId, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0",
+            sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithDuplicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithKeyThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Id));
+
+        Assert.Contains("Can't update [Id]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithIgnoreUpdateThrows()
+    {
+        var sqlGenerator = new SqlGenerator<Phone>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new Phone { Id = 10, Code = "ZZZ" }, x => x.Code));
+
+        Assert.Contains("[IgnoreUpdate]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithReadOnlyColumnThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.DisplayName));
+
+        Assert.Contains("not a mapped column", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateAnonymousWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new { Name = "John" });
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
+
+    [Fact]
+    public static void UpdateDictionaryWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new Dictionary<string, object> { { "Name", "John" } });
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
 }

--- a/tests/SqlGenerator.Tests/OracleGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/OracleGeneratorTests.cs
@@ -662,4 +662,91 @@ public class OracleGeneratorTests
 
         Assert.Contains("only for MySQL", ex.Message);
     }
+
+    [Fact]
+    public static void UpdateColumns()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(user, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Users.Name = :UserName, Users.UpdatedAt = :UserUpdatedAt WHERE Users.Id = :UserId", sqlQuery.GetSql());
+        Assert.NotNull(user.UpdatedAt);
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.Equal(3, parameters.Count);
+        Assert.Equal("John", parameters["UserName"]);
+        Assert.Equal(10, parameters["UserId"]);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithPredicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(x => x.Id == 10, user, x => x.Name, x => x.AddressId);
+
+        Assert.Equal("UPDATE Users SET Users.Name = :UserName, Users.AddressId = :UserAddressId, Users.UpdatedAt = :UserUpdatedAt WHERE Users.Id = :Id_p0",
+            sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithDuplicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Users.Name = :UserName, Users.UpdatedAt = :UserUpdatedAt WHERE Users.Id = :UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithKeyThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Id));
+
+        Assert.Contains("Can't update [Id]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithIgnoreUpdateThrows()
+    {
+        var sqlGenerator = new SqlGenerator<Phone>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new Phone { Id = 10, Code = "ZZZ" }, x => x.Code));
+
+        Assert.Contains("[IgnoreUpdate]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithReadOnlyColumnThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.DisplayName));
+
+        Assert.Contains("not a mapped column", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateAnonymousWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new { Name = "John" });
+
+        Assert.Equal("UPDATE Users SET Users.Name = :UserName, Users.UpdatedAt = :UserUpdatedAt WHERE Users.Id = :Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
+
+    [Fact]
+    public static void UpdateDictionaryWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new Dictionary<string, object> { { "Name", "John" } });
+
+        Assert.Equal("UPDATE Users SET Users.Name = :UserName, Users.UpdatedAt = :UserUpdatedAt WHERE Users.Id = :Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
 }

--- a/tests/SqlGenerator.Tests/PostgreSQLGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/PostgreSQLGeneratorTests.cs
@@ -181,4 +181,100 @@ public class PostgreSQLGeneratorTests
 
         Assert.Contains("only for MySQL", ex.Message);
     }
+
+    [Fact]
+    public static void UpdateColumns()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(user, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+        Assert.NotNull(user.UpdatedAt);
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.Equal(3, parameters.Count);
+        Assert.Equal("John", parameters["UserName"]);
+        Assert.Equal(10, parameters["UserId"]);
+    }
+
+    [Fact]
+    public static void UpdateColumns_QuoMarks()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name);
+
+        Assert.Equal("UPDATE \"Users\" SET \"Name\" = @UserName, \"UpdatedAt\" = @UserUpdatedAt WHERE \"Users\".\"Id\" = @UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithPredicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(x => x.Id == 10, user, x => x.Name, x => x.AddressId);
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, AddressId = @UserAddressId, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0",
+            sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithDuplicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithKeyThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Id));
+
+        Assert.Contains("Can't update [Id]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithIgnoreUpdateThrows()
+    {
+        var sqlGenerator = new SqlGenerator<Phone>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new Phone { Id = 10, Code = "ZZZ" }, x => x.Code));
+
+        Assert.Contains("[IgnoreUpdate]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithReadOnlyColumnThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.DisplayName));
+
+        Assert.Contains("not a mapped column", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateAnonymousWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new { Name = "John" });
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
+
+    [Fact]
+    public static void UpdateDictionaryWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new Dictionary<string, object> { { "Name", "John" } });
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
 }

--- a/tests/SqlGenerator.Tests/SQLiteGeneratorTests.cs
+++ b/tests/SqlGenerator.Tests/SQLiteGeneratorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using MicroOrm.Dapper.Repositories.SqlGenerator;
 using MicroOrm.Dapper.Repositories.SqlGenerator.Filters;
 using TestClasses;
@@ -63,5 +64,101 @@ public class SQLiteGeneratorTests
         var ex = Assert.Throws<NotSupportedException>(() => sqlGenerator.GetUpdate(user, x => x.Addresses));
 
         Assert.Contains("only for MySQL", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumns()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(user, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+        Assert.NotNull(user.UpdatedAt);
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.Equal(3, parameters.Count);
+        Assert.Equal("John", parameters["UserName"]);
+        Assert.Equal(10, parameters["UserId"]);
+    }
+
+    [Fact]
+    public static void UpdateColumns_QuoMarks()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector, true);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name);
+
+        Assert.Equal("UPDATE `Users` SET `Name` = @UserName, `UpdatedAt` = @UserUpdatedAt WHERE `Users`.`Id` = @UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithPredicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Name = "John", AddressId = 5 };
+        var sqlQuery = sqlGenerator.GetUpdateColumns(x => x.Id == 10, user, x => x.Name, x => x.AddressId);
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, AddressId = @UserAddressId, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0",
+            sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithDuplicate()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Name, x => x.Name);
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithKeyThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.Id));
+
+        Assert.Contains("Can't update [Id]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithIgnoreUpdateThrows()
+    {
+        var sqlGenerator = new SqlGenerator<Phone>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new Phone { Id = 10, Code = "ZZZ" }, x => x.Code));
+
+        Assert.Contains("[IgnoreUpdate]", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateColumnsWithReadOnlyColumnThrows()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var ex = Assert.Throws<ArgumentException>(() => sqlGenerator.GetUpdateColumns(new User { Id = 10, Name = "John" }, x => x.DisplayName));
+
+        Assert.Contains("not a mapped column", ex.Message);
+    }
+
+    [Fact]
+    public static void UpdateAnonymousWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new { Name = "John" });
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
+    }
+
+    [Fact]
+    public static void UpdateDictionaryWithUpdatedAt()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new Dictionary<string, object> { { "Name", "John" } });
+
+        Assert.Equal("UPDATE Users SET Name = @UserName, UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.IsType<DateTime>(parameters["UserUpdatedAt"]);
     }
 }

--- a/tests/SqlGenerator.Tests/UpdatedAtTests.cs
+++ b/tests/SqlGenerator.Tests/UpdatedAtTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using MicroOrm.Dapper.Repositories.SqlGenerator;
+using TestClasses;
+using Xunit;
+
+namespace SqlGenerator.Tests;
+
+public class UpdatedAtTests
+{
+    private const SqlProvider _sqlConnector = SqlProvider.MSSQL;
+
+    [Fact]
+    public static void InsertSetsUtcNow()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Name = "John" };
+
+        var before = DateTime.UtcNow;
+        sqlGenerator.GetInsert(user);
+
+        Assert.InRange(user.UpdatedAt.Value, before, DateTime.UtcNow);
+    }
+
+    [Fact]
+    public static void UpdateSetsUtcNow()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John" };
+
+        var before = DateTime.UtcNow;
+        sqlGenerator.GetUpdate(user);
+
+        Assert.InRange(user.UpdatedAt.Value, before, DateTime.UtcNow);
+    }
+
+    [Fact]
+    public static void LogicalDeleteSetsUtcNow()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10 };
+
+        var before = DateTime.UtcNow;
+        sqlGenerator.GetDelete(user);
+
+        Assert.InRange(user.UpdatedAt.Value, before, DateTime.UtcNow);
+    }
+
+    [Fact]
+    public static void LocalTimeKindSetsLocalNow()
+    {
+        var sqlGenerator = new SqlGenerator<UpdatedAtLocal>(_sqlConnector);
+        var entity = new UpdatedAtLocal { Id = 10, Name = "John" };
+
+        var before = DateTime.Now;
+        sqlGenerator.GetUpdate(entity);
+
+        Assert.InRange(entity.UpdatedAt.Value, before, DateTime.Now);
+    }
+
+    [Fact]
+    public static void OffSetShiftsTheValue()
+    {
+        var sqlGenerator = new SqlGenerator<UpdatedAtOffSet>(_sqlConnector);
+        var entity = new UpdatedAtOffSet { Id = 10, Name = "John" };
+
+        var before = DateTime.UtcNow.AddHours(3);
+        sqlGenerator.GetUpdate(entity);
+
+        Assert.InRange(entity.UpdatedAt.Value, before, DateTime.UtcNow.AddHours(3));
+    }
+
+    [Fact]
+    public static void BulkInsertSetsEveryEntity()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var users = new List<User> { new() { Name = "John" }, new() { Name = "Jane" } };
+
+        sqlGenerator.GetBulkInsert(users);
+
+        Assert.All(users, user => Assert.NotNull(user.UpdatedAt));
+    }
+
+    [Fact]
+    public static void BulkUpdateSetsEveryEntity()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var users = new List<User> { new() { Id = 10, Name = "John" }, new() { Id = 11, Name = "Jane" } };
+
+        sqlGenerator.GetBulkUpdate(users);
+
+        Assert.All(users, user => Assert.NotNull(user.UpdatedAt));
+    }
+
+    [Fact]
+    public static void EntityWithoutUpdatedAtGetsNoColumn()
+    {
+        var sqlGenerator = new SqlGenerator<Phone>(_sqlConnector);
+        var sqlQuery = sqlGenerator.GetUpdateColumns(new Phone { Id = 10, PNumber = "111" }, x => x.PNumber);
+
+        Assert.Equal("UPDATE DAB.Phones SET DAB.Phones.PNumber = @PhonePNumber WHERE DAB.Phones.Id = @PhoneId", sqlQuery.GetSql());
+    }
+
+    [Fact]
+    public static void IgnoreUpdateKeepsColumnOutOfUpdate()
+    {
+        var sqlGenerator = new SqlGenerator<UpdatedAtIgnored>(_sqlConnector);
+        var entity = new UpdatedAtIgnored { Id = 10, Name = "John" };
+
+        Assert.Equal("UPDATE UpdatedAtIgnored SET UpdatedAtIgnored.Name = @UpdatedAtIgnoredName WHERE UpdatedAtIgnored.Id = @UpdatedAtIgnoredId",
+            sqlGenerator.GetUpdate(entity).GetSql());
+
+        Assert.Equal("UPDATE UpdatedAtIgnored SET UpdatedAtIgnored.Name = @UpdatedAtIgnoredName WHERE UpdatedAtIgnored.Id = @UpdatedAtIgnoredId",
+            sqlGenerator.GetUpdateColumns(entity, x => x.Name).GetSql());
+
+        Assert.Equal("UPDATE UpdatedAtIgnored SET UpdatedAtIgnored.Name = @UpdatedAtIgnoredName WHERE UpdatedAtIgnored.Id = @Id_p0",
+            sqlGenerator.GetUpdate(x => x.Id == 10, new { Name = "John" }).GetSql());
+    }
+
+    [Fact]
+    public static void ListedColumnIsNotDuplicated()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var user = new User { Id = 10, Name = "John" };
+
+        var before = DateTime.UtcNow;
+        var sqlQuery = sqlGenerator.GetUpdateColumns(user, x => x.UpdatedAt);
+
+        Assert.Equal("UPDATE Users SET Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @UserId", sqlQuery.GetSql());
+        Assert.InRange(user.UpdatedAt.Value, before, DateTime.UtcNow);
+    }
+
+    [Fact]
+    public static void ExplicitValueIsKept()
+    {
+        var sqlGenerator = new SqlGenerator<User>(_sqlConnector);
+        var updatedAt = new DateTime(2020, 1, 1);
+
+        var sqlQuery = sqlGenerator.GetUpdate(x => x.Id == 10, new { Name = "John", UpdatedAt = updatedAt });
+
+        Assert.Equal("UPDATE Users SET Users.Name = @UserName, Users.UpdatedAt = @UserUpdatedAt WHERE Users.Id = @Id_p0", sqlQuery.GetSql());
+
+        var parameters = sqlQuery.Param as IDictionary<string, object>;
+        Assert.Equal(updatedAt, parameters["UserUpdatedAt"]);
+    }
+}

--- a/tests/TestClasses/UpdatedAtIgnored.cs
+++ b/tests/TestClasses/UpdatedAtIgnored.cs
@@ -1,0 +1,13 @@
+using System;
+using MicroOrm.Dapper.Repositories.Attributes;
+
+namespace TestClasses;
+
+public class UpdatedAtIgnored : BaseEntity<int>
+{
+    public string Name { get; set; }
+
+    [UpdatedAt]
+    [IgnoreUpdate]
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/tests/TestClasses/UpdatedAtLocal.cs
+++ b/tests/TestClasses/UpdatedAtLocal.cs
@@ -1,0 +1,12 @@
+using System;
+using MicroOrm.Dapper.Repositories.Attributes;
+
+namespace TestClasses;
+
+public class UpdatedAtLocal : BaseEntity<int>
+{
+    public string Name { get; set; }
+
+    [UpdatedAt(TimeKind = DateTimeKind.Local)]
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/tests/TestClasses/UpdatedAtOffSet.cs
+++ b/tests/TestClasses/UpdatedAtOffSet.cs
@@ -1,0 +1,12 @@
+using System;
+using MicroOrm.Dapper.Repositories.Attributes;
+
+namespace TestClasses;
+
+public class UpdatedAtOffSet : BaseEntity<int>
+{
+    public string Name { get; set; }
+
+    [UpdatedAt(OffSet = 3)]
+    public DateTime? UpdatedAt { get; set; }
+}


### PR DESCRIPTION
`UpdateColumns` writes only the columns you name instead of every mapped column, on both `ISqlGenerator` and `IDapperRepository`. A column that isn't mapped, or is marked `[Key]` or `[IgnoreUpdate]`, throws an `ArgumentException` naming the property. `[UpdatedAt]` is written along with the listed columns, and the anonymous object and dictionary overloads now set it too.

Ref #581